### PR TITLE
Implement PRD skeleton and initial PySide6 app (feature/prd-complete)

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,16 @@
+This PR bootstraps the BFB (BITS Form Builder) project.
+
+Changes:
+- Adds `PRD.md` with finalized product requirements
+- Adds minimal PySide6 app skeleton (`app/`), models (`app/models/form_model.py`), and a WPClient stub
+- Adds basic unit test(s) and README files
+
+Acceptance criteria:
+- App can be launched with `python -m app.main`
+- Tests (`pytest`) pass
+- PRD reflects the expected MVP and integration plan
+
+Next steps:
+- Implement Add Field dialog and Field Editor
+- Wire Save/Load and Publish calls
+- Add CI workflow and accessibility smoke tests

--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -5,4 +5,7 @@ This PR bootstraps the BFB project with:
 - Minimal PySide6 skeleton and models
 - Basic unit tests and README files
 
-See `PR_DESCRIPTION.md` for details.
+Next steps:
+- Add Add Field dialog and Field Editor
+- Wire Save/Load and Publish call
+- Add CI workflow and accessibility smoke tests

--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -1,0 +1,8 @@
+PR: feature/prd-complete -> main
+
+This PR bootstraps the BFB project with:
+- Finalized `PRD.md` with deliverables and QA plan
+- Minimal PySide6 skeleton and models
+- Basic unit tests and README files
+
+See `PR_DESCRIPTION.md` for details.


### PR DESCRIPTION
This PR bootstraps the BFB (BITS Form Builder) repo and implements the initial skeleton described in PRD.

Changes:
- `PRD.md` finalized
- Minimal PySide6 app skeleton (main window), models, and WP client stub
- Basic unit test

Next:
- Add Add Field dialog and Field Editor
- Wire Save/Load and Publish call
- Add CI workflow and accessibility smoke tests
